### PR TITLE
Thrust Imbalance Check

### DIFF
--- a/Controls/ThrustBalance.Designer.cs
+++ b/Controls/ThrustBalance.Designer.cs
@@ -39,13 +39,6 @@ namespace MissionPlanner.Controls
             this.servo3_lbl = new System.Windows.Forms.Label();
             this.servo4_lbl = new System.Windows.Forms.Label();
             this.update_timer = new System.Windows.Forms.Timer(this.components);
-            this.motorBalanceChecker = new FlightData.motorBalanceChecker();
-            this.colorGradient =
-                GetColorBand(
-                    100,
-                    new[] { System.Drawing.Color.LimeGreen, System.Drawing.Color.Yellow, System.Drawing.Color.Red },
-                    new[] {50, 80}
-                ).ToArray();
             this.SuspendLayout();
             // 
             // servo1_lbl

--- a/Controls/ThrustBalance.Designer.cs
+++ b/Controls/ThrustBalance.Designer.cs
@@ -40,7 +40,12 @@ namespace MissionPlanner.Controls
             this.servo4_lbl = new System.Windows.Forms.Label();
             this.update_timer = new System.Windows.Forms.Timer(this.components);
             this.motorBalanceChecker = new FlightData.motorBalanceChecker();
-            this.colorGradient = GetColorGradient(System.Drawing.Color.LimeGreen, System.Drawing.Color.Red, 99).ToArray();
+            this.colorGradient =
+                GetColorBand(
+                    100,
+                    new[] { System.Drawing.Color.LimeGreen, System.Drawing.Color.Yellow, System.Drawing.Color.Red },
+                    new[] {50, 80}
+                ).ToArray();
             this.SuspendLayout();
             // 
             // servo1_lbl

--- a/Controls/ThrustBalance.Designer.cs
+++ b/Controls/ThrustBalance.Designer.cs
@@ -43,6 +43,7 @@ namespace MissionPlanner.Controls
             this.servo4_pct = new System.Windows.Forms.Label();
             this.servo4_lbl = new System.Windows.Forms.Label();
             this.update_timer = new System.Windows.Forms.Timer(this.components);
+            this.motorBalanceChecker = new FlightData.motorBalanceChecker();
             this.SuspendLayout();
             // 
             // servo1_pct

--- a/Controls/ThrustBalance.Designer.cs
+++ b/Controls/ThrustBalance.Designer.cs
@@ -34,75 +34,131 @@ namespace MissionPlanner.Controls
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            this.servo1_pct = new System.Windows.Forms.Label();
             this.servo1_lbl = new System.Windows.Forms.Label();
+            this.servo2_pct = new System.Windows.Forms.Label();
             this.servo2_lbl = new System.Windows.Forms.Label();
+            this.servo3_pct = new System.Windows.Forms.Label();
             this.servo3_lbl = new System.Windows.Forms.Label();
+            this.servo4_pct = new System.Windows.Forms.Label();
             this.servo4_lbl = new System.Windows.Forms.Label();
             this.update_timer = new System.Windows.Forms.Timer(this.components);
             this.SuspendLayout();
             // 
+            // servo1_pct
+            // 
+            this.servo1_pct.BackColor = System.Drawing.Color.Transparent;
+            this.servo1_pct.Font = new System.Drawing.Font("Tahoma", 19.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.servo1_pct.ForeColor = System.Drawing.Color.Green;
+            this.servo1_pct.Location = new System.Drawing.Point(170, 15);
+            this.servo1_pct.Name = "servo1_pct";
+            this.servo1_pct.Size = new System.Drawing.Size(77, 40);
+            this.servo1_pct.TabIndex = 2;
+            this.servo1_pct.Text = "0%";
+            this.servo1_pct.TextAlign = System.Drawing.ContentAlignment.BottomLeft;
+            // 
             // servo1_lbl
             // 
-            this.servo1_lbl.AutoSize = true;
             this.servo1_lbl.BackColor = System.Drawing.Color.Transparent;
-            this.servo1_lbl.Font = new System.Drawing.Font("Tahoma", 19.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.servo1_lbl.ForeColor = System.Drawing.Color.ForestGreen;
-            this.servo1_lbl.Location = new System.Drawing.Point(15, 15);
+            this.servo1_lbl.Font = new System.Drawing.Font("Tahoma", 17F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.servo1_lbl.ForeColor = System.Drawing.Color.White;
+            this.servo1_lbl.Location = new System.Drawing.Point(187, 49);
             this.servo1_lbl.Name = "servo1_lbl";
-            this.servo1_lbl.Size = new System.Drawing.Size(77, 40);
-            this.servo1_lbl.TabIndex = 2;
-            this.servo1_lbl.Text = "10₁";
-            this.servo1_lbl.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.servo1_lbl.Size = new System.Drawing.Size(30, 40);
+            this.servo1_lbl.Text = "1";
+            this.servo1_lbl.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // servo2_pct
+            // 
+            this.servo2_pct.AutoSize = true;
+            this.servo2_pct.BackColor = System.Drawing.Color.Transparent;
+            this.servo2_pct.Font = new System.Drawing.Font("Tahoma", 19.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.servo2_pct.ForeColor = System.Drawing.Color.Green;
+            this.servo2_pct.Location = new System.Drawing.Point(170, 150);
+            this.servo2_pct.Name = "servo2_lbl";
+            this.servo2_pct.Size = new System.Drawing.Size(77, 40);
+            this.servo2_pct.TabIndex = 3;
+            this.servo2_pct.Text = "0%";
+            this.servo2_pct.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             // 
             // servo2_lbl
             // 
-            this.servo2_lbl.AutoSize = true;
             this.servo2_lbl.BackColor = System.Drawing.Color.Transparent;
-            this.servo2_lbl.Font = new System.Drawing.Font("Tahoma", 19.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.servo2_lbl.ForeColor = System.Drawing.Color.ForestGreen;
-            this.servo2_lbl.Location = new System.Drawing.Point(170, 15);
+            this.servo2_lbl.Font = new System.Drawing.Font("Tahoma", 17F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.servo2_lbl.ForeColor = System.Drawing.Color.White;
+            this.servo2_lbl.Location = new System.Drawing.Point(187, 117);
             this.servo2_lbl.Name = "servo2_lbl";
-            this.servo2_lbl.Size = new System.Drawing.Size(77, 40);
-            this.servo2_lbl.TabIndex = 3;
-            this.servo2_lbl.Text = "₂10";
+            this.servo2_lbl.Size = new System.Drawing.Size(30, 40);
+            this.servo2_lbl.Text = "2";
+            this.servo2_lbl.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // servo3_pct
+            // 
+            this.servo3_pct.AutoSize = true;
+            this.servo3_pct.BackColor = System.Drawing.Color.Transparent;
+            this.servo3_pct.Font = new System.Drawing.Font("Tahoma", 19.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.servo3_pct.ForeColor = System.Drawing.Color.Green;
+            this.servo3_pct.Location = new System.Drawing.Point(15, 150);
+            this.servo3_pct.Name = "servo3_lbl";
+            this.servo3_pct.Size = new System.Drawing.Size(77, 40);
+            this.servo3_pct.TabIndex = 5;
+            this.servo3_pct.Text = "0%";
+            this.servo3_pct.TextAlign = System.Drawing.ContentAlignment.BottomRight;
             // 
             // servo3_lbl
             // 
-            this.servo3_lbl.AutoSize = true;
             this.servo3_lbl.BackColor = System.Drawing.Color.Transparent;
-            this.servo3_lbl.Font = new System.Drawing.Font("Tahoma", 19.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.servo3_lbl.ForeColor = System.Drawing.Color.ForestGreen;
-            this.servo3_lbl.Location = new System.Drawing.Point(170, 170);
+            this.servo3_lbl.Font = new System.Drawing.Font("Tahoma", 17F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.servo3_lbl.ForeColor = System.Drawing.Color.White;
+            this.servo3_lbl.Location = new System.Drawing.Point(31, 117);
             this.servo3_lbl.Name = "servo3_lbl";
-            this.servo3_lbl.Size = new System.Drawing.Size(77, 40);
-            this.servo3_lbl.TabIndex = 5;
-            this.servo3_lbl.Text = "³10";
+            this.servo3_lbl.Size = new System.Drawing.Size(30, 40);
+            this.servo3_lbl.Text = "3";
+            this.servo3_lbl.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // servo4_pct
+            // 
+            this.servo4_pct.AutoSize = true;
+            this.servo4_pct.BackColor = System.Drawing.Color.Transparent;
+            this.servo4_pct.Font = new System.Drawing.Font("Tahoma", 19.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.servo4_pct.ForeColor = System.Drawing.Color.Green;
+            this.servo4_pct.Location = new System.Drawing.Point(15, 15);
+            this.servo4_pct.Name = "servo4_lbl";
+            this.servo4_pct.Size = new System.Drawing.Size(77, 40);
+            this.servo4_pct.TabIndex = 4;
+            this.servo4_pct.Text = "0%";
+            this.servo4_pct.TextAlign = System.Drawing.ContentAlignment.BottomRight;
             // 
             // servo4_lbl
             // 
-            this.servo4_lbl.AutoSize = true;
             this.servo4_lbl.BackColor = System.Drawing.Color.Transparent;
-            this.servo4_lbl.Font = new System.Drawing.Font("Tahoma", 19.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.servo4_lbl.ForeColor = System.Drawing.Color.ForestGreen;
-            this.servo4_lbl.Location = new System.Drawing.Point(15, 170);
+            this.servo4_lbl.Font = new System.Drawing.Font("Tahoma", 17F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.servo4_lbl.ForeColor = System.Drawing.Color.White;
+            this.servo4_lbl.Location = new System.Drawing.Point(31, 49);
             this.servo4_lbl.Name = "servo4_lbl";
-            this.servo4_lbl.Size = new System.Drawing.Size(77, 40);
-            this.servo4_lbl.TabIndex = 4;
-            this.servo4_lbl.Text = "10⁴";
-            this.servo4_lbl.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.servo4_lbl.Size = new System.Drawing.Size(30, 40);
+            this.servo4_lbl.Text = "4";
+            this.servo4_lbl.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // update_timer
+            // 
+            this.update_timer.Tick += new System.EventHandler(this.update_timer_Tick);
             // 
             // ThrustBalance
             // 
             this.AutoSize = true;
-            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.BackColor = System.Drawing.SystemColors.ControlText;
             this.BackgroundImage = global::MissionPlanner.Properties.Resources.quadframesnormal_03;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
             this.ClientSize = new System.Drawing.Size(240, 220);
-            this.Controls.Add(this.servo3_lbl);
-            this.Controls.Add(this.servo4_lbl);
-            this.Controls.Add(this.servo2_lbl);
+            this.Controls.Add(this.servo1_pct);
             this.Controls.Add(this.servo1_lbl);
+            this.Controls.Add(this.servo2_pct);
+            this.Controls.Add(this.servo2_lbl);
+            this.Controls.Add(this.servo3_pct);
+            this.Controls.Add(this.servo3_lbl);
+            this.Controls.Add(this.servo4_pct);
+            this.Controls.Add(this.servo4_lbl);
             this.DoubleBuffered = true;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
@@ -114,18 +170,18 @@ namespace MissionPlanner.Controls
             this.TopMost = true;
             this.ResumeLayout(false);
             this.PerformLayout();
-            // 
-            // update_timer
-            // 
-            this.update_timer.Tick += new System.EventHandler(this.update_timer_Tick);
 
         }
 
         #endregion
+        private System.Windows.Forms.Label servo1_pct;
         private System.Windows.Forms.Label servo1_lbl;
+        private System.Windows.Forms.Label servo2_pct;
         private System.Windows.Forms.Label servo2_lbl;
-        private System.Windows.Forms.Label servo4_lbl;
+        private System.Windows.Forms.Label servo3_pct;
         private System.Windows.Forms.Label servo3_lbl;
+        private System.Windows.Forms.Label servo4_pct;
+        private System.Windows.Forms.Label servo4_lbl;
         private System.Windows.Forms.Timer update_timer;
         private FlightData.motorBalanceChecker motorBalanceChecker;
         private System.Drawing.Color[] colorGradient;

--- a/Controls/ThrustBalance.cs
+++ b/Controls/ThrustBalance.cs
@@ -17,6 +17,12 @@ namespace MissionPlanner.Controls
         {
             InitializeComponent();
 
+            colorGradient =
+                GetColorBand(
+                    100,
+                    new[] { System.Drawing.Color.LimeGreen, System.Drawing.Color.Yellow, System.Drawing.Color.Red },
+                    new[] { 50, 80 }
+                ).ToArray();
             Utilities.ThemeManager.ApplyThemeTo(this);
 
             update_timer_Tick(null, null);

--- a/Controls/ThrustBalance.cs
+++ b/Controls/ThrustBalance.cs
@@ -41,6 +41,35 @@ namespace MissionPlanner.Controls
             this.servo3_lbl.ForeColor = colorGradient[servo3_pct];
             this.servo4_lbl.ForeColor = colorGradient[servo4_pct];
         }
+        
+        private static IEnumerable<Color> GetColorBand(int size, Color[] color, int[] band = null)
+        {
+            
+            if (band is null)
+            {
+                band = Array.Empty<int>();
+            };
+            int bandDiff = color.Length - band.Length;
+            if (bandDiff > 0)
+            {
+                int lastBand = band.Length > 0 ? band[band.Length - 1] : 0;
+                for (int i = 1; i < bandDiff + 1; i++)
+                {
+                    band = band.Append(lastBand + i * (size - lastBand) / bandDiff).ToArray();
+                };
+            };
+            
+            var total = color.Zip(band, (c, b) => new { Color = c, Band = b });
+            int cur_size = 0;
+            foreach (var cb in total)
+            {
+                for (int i = 0; i < cb.Band - cur_size; i++)
+                {
+                    yield return cb.Color;
+                }
+                cur_size = cb.Band;
+            };
+        }
         private static IEnumerable<Color> GetColorGradient(Color from, Color to, int totalNumberOfColors)
         {
             if (totalNumberOfColors < 2)

--- a/Controls/ThrustBalance.cs
+++ b/Controls/ThrustBalance.cs
@@ -37,15 +37,15 @@ namespace MissionPlanner.Controls
             int servo4_pct = (int)(motorBalanceChecker.motor4_pct * 100);
 
             motorBalanceChecker.update();
-            this.servo1_lbl.Text = $"{servo1_pct}₁";
-            this.servo2_lbl.Text = $"₂{servo2_pct}";
-            this.servo3_lbl.Text = $"³{servo3_pct}";
-            this.servo4_lbl.Text = $"{servo4_pct}⁴";
+            this.servo1_pct.ForeColor = colorGradient[servo1_pct];
+            this.servo2_pct.ForeColor = colorGradient[servo2_pct];
+            this.servo3_pct.ForeColor = colorGradient[servo3_pct];
+            this.servo4_pct.ForeColor = colorGradient[servo4_pct];
 
-            this.servo1_lbl.ForeColor = colorGradient[servo1_pct];
-            this.servo2_lbl.ForeColor = colorGradient[servo2_pct];
-            this.servo3_lbl.ForeColor = colorGradient[servo3_pct];
-            this.servo4_lbl.ForeColor = colorGradient[servo4_pct];
+            this.servo1_pct.Text = $"{servo1_pct}%";
+            this.servo2_pct.Text = $"{servo2_pct}%";
+            this.servo3_pct.Text = $"{servo3_pct}%";
+            this.servo4_pct.Text = $"{servo4_pct}%";
         }
         
         private static IEnumerable<Color> GetColorBand(int size, Color[] color, int[] band = null)

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -242,10 +242,10 @@ namespace MissionPlanner.GCSViews
         // Thrust imbalance check sctruct
         public struct motorBalanceChecker
         {
-            private const int MAX_RAW_INPUT = 2000;
-            private const int MIN_RAW_INPUT = 1000;
-            private const int DT_RAW_INPUT = MAX_RAW_INPUT - MIN_RAW_INPUT;
             private const float IMBALANCE_THRESHOLD = 1.25f;
+            private int MAX_RAW_INPUT;
+            private int MIN_RAW_INPUT;
+            private int DT_RAW_INPUT;
 
             public float motor1_pct;
             public float motor2_pct;
@@ -256,6 +256,9 @@ namespace MissionPlanner.GCSViews
 
             public motorBalanceChecker(bool do_update = true)
             {
+                this.MAX_RAW_INPUT = 0;
+                this.MIN_RAW_INPUT = 0;
+                this.DT_RAW_INPUT = 0;
                 this.motor1_pct = 0;
                 this.motor2_pct = 0;
                 this.motor3_pct = 0;
@@ -269,10 +272,16 @@ namespace MissionPlanner.GCSViews
             }
             public void update()
             {
-                if (MainV2.comPort.BaseStream != null && MainV2.comPort.BaseStream.IsOpen)
+                if (MainV2.comPort.BaseStream != null && MainV2.comPort.BaseStream.IsOpen && MainV2.comPort.MAV.param.Count > 0)
                 {
-                    float[] motorall_raw = getMotorRaw();
+                    if (DT_RAW_INPUT == 0)
+                    {
+                        MAX_RAW_INPUT = (int)MainV2.comPort.MAV.param["MOT_PWM_MAX"];
+                        MIN_RAW_INPUT = (int)MainV2.comPort.MAV.param["MOT_PWM_MIN"];
+                        DT_RAW_INPUT = MAX_RAW_INPUT - MIN_RAW_INPUT;
+                    };
 
+                    float[] motorall_raw = getMotorRaw();
                     for (int i = 0; i < motorall_raw.Length; i++)
                     {
                         GetType()

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -261,7 +261,7 @@ namespace MissionPlanner.GCSViews
                 this.motor3_pct = 0;
                 this.motor4_pct = 0;
                 this.motor_diff = 1;
-                this.is_balanced = false;
+                this.is_balanced = true;
                 if (do_update)
                 {
                     this.update();


### PR DESCRIPTION
Added new feature called "Thrust balance".
There is a new button called "Thrust Imb" on the Copter page.
It turns red if maximum difference between all motor thrust readings exceeds 1.25 times.
On click it shows a window which displays a schematic image of a drone with all the motor thrust readings (in percentage) placed around it.
The motor readings displayed on "Thrust Balance" Window are color coded. The lower end values are displayed in Green, the middle range values are displayed in Yellow and the upper range values are displayed in Red.
The color range is currently defined as follows: 0-50% Green, 51-80% Yellow, 81-100% Red.
![зображення](https://github.com/user-attachments/assets/2e4dec07-e9fc-4cb1-8e9a-a361acdbd36c)
![зображення](https://github.com/user-attachments/assets/bf9a6961-e36c-44b9-9e83-0ec29befe4ba)
